### PR TITLE
upgrade `react-native-redash`

### DIFF
--- a/components/LiveCard.js
+++ b/components/LiveCard.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, StyleSheet } from 'react-native';
 import Svg, { Circle } from 'react-native-svg';
 import Animated, { Easing } from 'react-native-reanimated';
-import { loop, bInterpolate } from 'react-native-redash';
+import { loop, mix } from 'react-native-redash';
 import Colors from '../constants/Colors';
 import { Subtitle } from './shared/Typography';
 
@@ -27,7 +27,7 @@ function AnimatedCircle() {
     [animation]
   );
 
-  const opacity = bInterpolate(animation, 0.1, 1);
+  const opacity = mix(animation, 0.1, 1);
 
   return (
     <Animated.View style={{ opacity }}>

--- a/ios/EchoChurch.xcodeproj/project.pbxproj
+++ b/ios/EchoChurch.xcodeproj/project.pbxproj
@@ -158,10 +158,9 @@
 			};
 			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "EchoChurch" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				English,
 				en,
 				Base,
 			);

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -359,7 +359,7 @@ DEPENDENCIES:
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - Amplitude-iOS
     - boost-for-react-native
 
@@ -551,4 +551,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 7f4c21e9567b9edf7b64e41ed7613898a792497c
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.9.1


### PR DESCRIPTION
there was a breaking change where `bInterpolate` was renamed to `mix`