### PR TITLE
add ability to tab thru forms ⏭

### DIFF
--- a/components/AskAboutGroupModal.js
+++ b/components/AskAboutGroupModal.js
@@ -1,4 +1,4 @@
-import React, { useReducer } from 'react';
+import React, { useReducer, useRef } from 'react';
 import { StyleSheet, View } from 'react-native';
 import * as Amplitude from 'expo-analytics-amplitude';
 import { Formik } from 'formik';
@@ -38,6 +38,9 @@ function reducer(state, action) {
 
 export default function AskAboutGroupModal({ groupID, title, showSuccess }) {
   const [{ loading, success }, dispatch] = useReducer(reducer, initialState);
+  const lastNameRef = useRef(null);
+  const emailRef = useRef(null);
+  const questionRef = useRef(null);
 
   const handleOpenModal = () => {
     Amplitude.logEventWithProperties('OPEN Group Ask Question', {
@@ -106,44 +109,56 @@ export default function AskAboutGroupModal({ groupID, title, showSuccess }) {
             <View>
               <Input
                 autoCompleteType="name"
+                blurOnSubmit={false}
                 label="First Name"
                 placeholder="Andy"
+                returnKeyType="next"
                 textContentType="givenName"
                 touched={touched.firstName}
                 value={values.firstName}
                 errors={errors.firstName}
                 onChangeText={handleChange('firstName')}
                 onBlur={handleBlur('firstName')}
+                onSubmitEditing={() => lastNameRef.current.focus()}
               />
               <Input
                 autoCompleteType="name"
+                blurOnSubmit={false}
                 label="Last Name"
                 placeholder="Wood"
+                ref={lastNameRef}
+                returnKeyType="next"
                 textContentType="familyName"
                 touched={touched.lastName}
                 value={values.lastName}
                 errors={errors.lastName}
                 onChangeText={handleChange('lastName')}
                 onBlur={handleBlur('lastName')}
+                onSubmitEditing={() => emailRef.current.focus()}
               />
               <Input
                 autoCapitalize="none"
                 autoCompleteType="email"
                 autoCorrect={false}
+                blurOnSubmit={false}
                 clearButtonMode="while-editing"
                 keyboardType="email-address"
                 label="Email"
                 placeholder="andy@echo.church"
+                ref={emailRef}
+                returnKeyType="next"
                 textContentType="emailAddress"
                 touched={touched.email}
                 value={values.email}
                 errors={errors.email}
                 onChangeText={handleChange('email')}
                 onBlur={handleBlur('email')}
+                onSubmitEditing={() => questionRef.current.focus()}
               />
               <Input
                 label="Question"
                 placeholder="Ask a question..."
+                ref={questionRef}
                 touched={touched.question}
                 value={values.question}
                 errors={errors.question}

--- a/components/JoinGroupModal.js
+++ b/components/JoinGroupModal.js
@@ -1,4 +1,4 @@
-import React, { useReducer } from 'react';
+import React, { useReducer, useRef } from 'react';
 import { StyleSheet, View } from 'react-native';
 import * as Amplitude from 'expo-analytics-amplitude';
 import { Formik } from 'formik';
@@ -37,6 +37,8 @@ function reducer(state, action) {
 
 export default function JoinGroupModal({ groupID, title, showSuccess }) {
   const [{ loading, success }, dispatch] = useReducer(reducer, initialState);
+  const lastNameRef = useRef(null);
+  const emailRef = useRef(null);
 
   const handleOpenModal = () => {
     Amplitude.logEventWithProperties('OPEN Group Sign Up', {
@@ -104,25 +106,32 @@ export default function JoinGroupModal({ groupID, title, showSuccess }) {
             <View>
               <Input
                 autoCompleteType="name"
+                blurOnSubmit={false}
                 label="First Name"
                 placeholder="Andy"
+                returnKeyType="next"
                 textContentType="givenName"
                 touched={touched.firstName}
                 value={values.firstName}
                 errors={errors.firstName}
                 onChangeText={handleChange('firstName')}
                 onBlur={handleBlur('firstName')}
+                onSubmitEditing={() => lastNameRef.current.focus()}
               />
               <Input
                 autoCompleteType="name"
+                blurOnSubmit={false}
                 label="Last Name"
                 placeholder="Wood"
+                ref={lastNameRef}
+                returnKeyType="next"
                 textContentType="familyName"
                 touched={touched.lastName}
                 value={values.lastName}
                 errors={errors.lastName}
                 onChangeText={handleChange('lastName')}
                 onBlur={handleBlur('lastName')}
+                onSubmitEditing={() => emailRef.current.focus()}
               />
               <Input
                 autoCapitalize="none"
@@ -132,6 +141,7 @@ export default function JoinGroupModal({ groupID, title, showSuccess }) {
                 keyboardType="email-address"
                 label="Email"
                 placeholder="andy@echo.church"
+                ref={emailRef}
                 textContentType="emailAddress"
                 touched={touched.email}
                 value={values.email}

--- a/components/shared/TextInput.js
+++ b/components/shared/TextInput.js
@@ -3,7 +3,7 @@ import { StyleSheet, View, TextInput } from 'react-native';
 import Colors from '../../constants/Colors';
 import { Text } from './Typography';
 
-export default function Input(props) {
+function Input(props, ref) {
   const { label, touched, errors, ...inputProps } = props;
   const showError = errors && touched;
 
@@ -19,6 +19,7 @@ export default function Input(props) {
         keyboardAppearance="dark"
         returnKeyType="done"
         placeholderTextColor="rgba(255, 255, 255, 0.5)"
+        ref={ref}
         style={[
           styles.input,
           { borderColor: showError ? Colors.red : Colors.darkGray },
@@ -60,3 +61,7 @@ const styles = StyleSheet.create({
     paddingVertical: 10,
   },
 });
+
+// make sure we're forwarding refs
+// https://reactjs.org/docs/forwarding-refs.html
+export default React.forwardRef(Input);


### PR DESCRIPTION
since native forms don't include those nice 🔼 🔽 buttons to tab thru forms, we need to implement this ourselves using `refs` to the next field and `returnKeyType="next"`

![gif](https://user-images.githubusercontent.com/1015884/83099381-0f2bf680-a062-11ea-9ae6-87fbfedab617.gif)
