### PR TITLE
fix wordpress post image src & blog post priority

### DIFF
--- a/data/blogPosts.js
+++ b/data/blogPosts.js
@@ -22,7 +22,8 @@ export async function getBlogPosts() {
         date,
         _links: links = {},
       } = {}) => {
-        const [{ href: imageUrl } = {}] = links['wp:featuredmedia'] || [];
+        const [{ href: imageUrl } = {}] =
+          links['wp:featuredmedia'] || links['wp:attachment'] || [];
         const postDate = new Date(date).toLocaleDateString();
 
         if (!imageUrl) {
@@ -36,7 +37,9 @@ export async function getBlogPosts() {
 
         return axios
           .get(imageUrl)
-          .then(({ data: { link: image } = {} } = {}) => {
+          .then(({ data = [] } = {}) => {
+            const [{ link: image } = {}] = Array.isArray(data) ? data : [data];
+
             return {
               type: 'BLOG',
               url: blogUrl,

--- a/screens/Home.js
+++ b/screens/Home.js
@@ -75,8 +75,21 @@ const HomeScreen = () => {
 
       // get all the posts and sort them descending by date
       const posts = [...blogPosts, ...igPosts].sort(
-        ({ date: firstDate }, { date: secondDate }) =>
-          new Date(secondDate) - new Date(firstDate)
+        (firstPost = {}, secondPost = {}) => {
+          const { date: firstDate, type: firstType } = firstPost;
+          const { date: secondDate, type: secondType } = secondPost;
+
+          if (firstDate === secondDate) {
+            if (firstType === 'BLOG') {
+              return -1;
+            }
+            if (secondType === 'BLOG') {
+              return 1;
+            }
+          }
+
+          return new Date(secondDate) - new Date(firstDate);
+        }
       );
       const [firstPost, secondPost, ...restOfPosts] = posts;
 


### PR DESCRIPTION
- wordpress post images can come from `wp:featuredmedia` and `wp:attachment`, so we needed to add support for both, although **we should agree on blog post writers that `wp:featuredmedia` should always be populated**
- if posts are published on the _same day_, blog posts take precedence over IG posts

![posts](https://user-images.githubusercontent.com/1015884/84239757-e2d89700-aab1-11ea-9d58-4f16caec2a9c.png)
