### PR TITLE
dont cache the wordpress posts

### DIFF
--- a/data/blogPosts.js
+++ b/data/blogPosts.js
@@ -18,7 +18,10 @@ function formatDate(date) {
 export async function getBlogPosts() {
   const { data: posts = [] } =
     (await axios
-      .get('https://echo.church/wp-json/wp/v2/posts?per_page=10&orderby=date')
+      .get(
+        `https://echo.church/wp-json/wp/v2/posts?per_page=10&orderby=date&timestamp=${new Date().getTime()}`,
+        { headers: { 'Cache-Control': 'no-cache' } }
+      )
       .catch((err) => {
         Amplitude.logEventWithProperties('ERROR loading blog posts', {
           error: err,


### PR DESCRIPTION
it seems like the wordpress posts were getting cached 🤷‍♂️
following this post https://stackoverflow.com/a/49263912, added a query param to basically invalidate that cache

also added the `cache-control` header just in case too
